### PR TITLE
Make LOD screen-space based

### DIFF
--- a/examples/LOD.ts
+++ b/examples/LOD.ts
@@ -1,14 +1,15 @@
 import { createRadixSort, extendBatchedMeshPrototype, getBatchedMeshLODCount } from '@three.ez/batched-mesh-extensions';
 import { Main, PerspectiveCameraAuto } from '@three.ez/main';
 import { performanceRangeLOD, simplifyGeometriesByErrorLOD } from '@three.ez/simplify-geometry';
-import { AmbientLight, BatchedMesh, Color, DirectionalLight, Fog, Matrix4, MeshStandardMaterial, Quaternion, Scene, TorusKnotGeometry, Vector3, WebGLCoordinateSystem } from 'three';
+import { AmbientLight, BatchedMesh, Color, DirectionalLight, Fog, Matrix4, MeshStandardMaterial, OrthographicCamera, Quaternion, Scene, SphereGeometry, TorusKnotGeometry, Vector3, WebGLCoordinateSystem } from 'three';
 import { MapControls } from 'three/examples/jsm/Addons.js';
 
 // EXTEND BATCHEDMESH PROTOTYPE
 extendBatchedMeshPrototype();
 
 const instancesCount = 500000;
-const camera = new PerspectiveCameraAuto(50, 0.1, 600).translateZ(50).translateY(10);
+// const camera = new PerspectiveCameraAuto(50, 0.1, 600).translateZ(50).translateY(10);
+const camera = new OrthographicCamera(-window.innerWidth / 2, window.innerWidth / 2, window.innerHeight / 2, -window.innerHeight / 2, 0.1, 600).translateZ(50).translateY(10);
 const scene = new Scene();
 scene.fog = new Fog(0x000000, 500, 600);
 const main = new Main(); // init renderer and other stuff
@@ -33,6 +34,7 @@ const geometries = [
 // CREATE SIMPLIFIED GEOMETRIES
 
 const geometriesLODArray = await simplifyGeometriesByErrorLOD(geometries, 4, performanceRangeLOD);
+console.log('performanceRangeLOD', performanceRangeLOD);
 
 // CREATE BATCHED MESH
 
@@ -45,10 +47,10 @@ batchedMesh.customSort = createRadixSort(batchedMesh);
 for (let i = 0; i < geometriesLODArray.length; i++) {
   const geometryLOD = geometriesLODArray[i];
   const geometryId = batchedMesh.addGeometry(geometryLOD[0], -1, LODIndexCount[i]);
-  batchedMesh.addGeometryLOD(geometryId, geometryLOD[1], 15);
-  batchedMesh.addGeometryLOD(geometryId, geometryLOD[2], 75);
-  batchedMesh.addGeometryLOD(geometryId, geometryLOD[3], 125);
-  batchedMesh.addGeometryLOD(geometryId, geometryLOD[4], 200);
+  batchedMesh.addGeometryLOD(geometryId, geometryLOD[1], 0.50); // use from below 50% of the screen space
+  batchedMesh.addGeometryLOD(geometryId, geometryLOD[2], 0.20); // use below 20%
+  batchedMesh.addGeometryLOD(geometryId, geometryLOD[3], 0.10); // etc
+  batchedMesh.addGeometryLOD(geometryId, geometryLOD[4], 0.05);
 }
 
 // ADD INSTANCES

--- a/src/core/feature/LOD.ts
+++ b/src/core/feature/LOD.ts
@@ -7,20 +7,20 @@ export type LODInfo = { start: number; count: number; distance: number; hysteres
 declare module 'three' {
   interface BatchedMesh {
     /**
-         * Adds a Level of Detail (LOD) geometry to the BatchedMesh.
-         * @param geometryId The ID of the geometry to which the LOD is being added.
-         * @param geometryOrIndex The BufferGeometry to be added as LOD or the index array.
-         * @param distance The screen-space metric (e.g., fraction of screen height) at which this LOD should be used.
-         * @param hysteresis Optional hysteresis value for LOD transition.
-         */
+     * Adds a Level of Detail (LOD) geometry to the BatchedMesh.
+     * @param geometryId The ID of the geometry to which the LOD is being added.
+     * @param geometryOrIndex The BufferGeometry to be added as LOD or the index array.
+     * @param distance The screen-space metric (e.g., fraction of screen height) at which this LOD should be used.
+     * @param hysteresis Optional hysteresis value for LOD transition.
+     */
     addGeometryLOD(geometryId: number, geometryOrIndex: BufferGeometry | TypedArray, distance: number, hysteresis?: number): void;
     /**
-         * Retrieves the LOD index for a given screen-space metric.
-         * @param LOD The array of LOD information.
-         * @param metric The calculated screen-space metric for the object.
-         * @param useDistSquared Whether to use the squared distance for LOD calculations.
-         * @returns The index of the appropriate LOD
-         */
+     * Retrieves the LOD index for a given screen-space metric.
+     * @param LOD The array of LOD information.
+     * @param metric The calculated screen-space metric for the object.
+     * @param useDistSquared Whether to use the squared distance for LOD calculations.
+     * @returns The index of the appropriate LOD
+     */
     getLODIndex(LOD: LODInfo[], metric: number, useDistSquared: boolean): number;
   }
 }

--- a/src/core/feature/LOD.ts
+++ b/src/core/feature/LOD.ts
@@ -2,34 +2,35 @@ import { BatchedMesh, BufferGeometry, TypedArray } from 'three';
 
 // TODO: add optional distance and first load function like InstancedMesh2
 
-export type LODInfo = { start: number; count: number; distance: number; hysteresis: number };
+export type LODInfo = { start: number; count: number; distance: number; hysteresis: number; distSquared: number };
 
 declare module 'three' {
   interface BatchedMesh {
     /**
-     * Adds a Level of Detail (LOD) geometry to the BatchedMesh.
-     * @param geometryId The ID of the geometry to which the LOD is being added.
-     * @param geometryOrIndex The BufferGeometry to be added as LOD or the index array.
-     * @param distance The distance at which this LOD should be used.
-     * @param hysteresis Optional hysteresis value for LOD transition.
-     */
+         * Adds a Level of Detail (LOD) geometry to the BatchedMesh.
+         * @param geometryId The ID of the geometry to which the LOD is being added.
+         * @param geometryOrIndex The BufferGeometry to be added as LOD or the index array.
+         * @param distance The screen-space metric (e.g., fraction of screen height) at which this LOD should be used.
+         * @param hysteresis Optional hysteresis value for LOD transition.
+         */
     addGeometryLOD(geometryId: number, geometryOrIndex: BufferGeometry | TypedArray, distance: number, hysteresis?: number): void;
     /**
-     * Retrieves the LOD index for a given distance.
-     * @param LOD The array of LOD information.
-     * @param distance The distance to check against the LODs.
-     * @returns The index of the appropriate LOD
-     */
-    getLODIndex(LOD: LODInfo[], distance: number): number;
+         * Retrieves the LOD index for a given screen-space metric.
+         * @param LOD The array of LOD information.
+         * @param metric The calculated screen-space metric for the object.
+         * @param useDistSquared Whether to use the squared distance for LOD calculations.
+         * @returns The index of the appropriate LOD
+         */
+    getLODIndex(LOD: LODInfo[], metric: number, useDistSquared: boolean): number;
   }
 }
 
 export function addGeometryLOD(this: BatchedMesh, geometryId: number, geoOrIndex: BufferGeometry | TypedArray, distance: number, hysteresis = 0): void {
   const geometryInfo = this._geometryInfo[geometryId];
   const srcIndexArray = (geoOrIndex as BufferGeometry).isBufferGeometry ? (geoOrIndex as BufferGeometry).index.array : geoOrIndex as TypedArray;
-  distance = distance ** 2;
+  const distSquared = distance ** 2;
 
-  geometryInfo.LOD ??= [{ start: geometryInfo.start, count: geometryInfo.count, distance: 0, hysteresis: 0 }];
+  geometryInfo.LOD ??= [{ start: geometryInfo.start, count: geometryInfo.count, distance: Infinity, hysteresis: 0, distSquared: Infinity }]; // Highest detail LOD has an infinite threshold
 
   const LOD = geometryInfo.LOD;
   const lastLOD = LOD[LOD.length - 1];
@@ -40,7 +41,7 @@ export function addGeometryLOD(this: BatchedMesh, geometryId: number, geoOrIndex
     throw new Error('BatchedMesh LOD: Reserved space request exceeds the maximum buffer size.');
   }
 
-  LOD.push({ start, count, distance, hysteresis });
+  LOD.push({ start, count, distance, distSquared, hysteresis });
 
   const dstIndex = this.geometry.getIndex();
   const dstIndexArray = dstIndex.array;
@@ -53,11 +54,11 @@ export function addGeometryLOD(this: BatchedMesh, geometryId: number, geoOrIndex
   dstIndex.needsUpdate = true;
 }
 
-export function getLODIndex(LODs: LODInfo[], distance: number): number {
+export function getLODIndex(LODs: LODInfo[], metric: number, useDistSquared: boolean): number {
   for (let i = LODs.length - 1; i > 0; i--) {
     const level = LODs[i];
-    const levelDistance = level.distance - (level.distance * level.hysteresis);
-    if (distance >= levelDistance) return i;
+    const levelDistance = useDistSquared ? level.distSquared - (level.distSquared * level.hysteresis) : level.distance - (level.distance * level.hysteresis);
+    if (metric < levelDistance) return i;
   }
 
   return 0;


### PR DESCRIPTION
new proposed API
```
  const geometryId = batchedMesh.addGeometry(geometryLOD[0], -1, LODIndexCount[i]);
  batchedMesh.addGeometryLOD(geometryId, geometryLOD[1], 0.50); // use from below 50% of the screen space
  batchedMesh.addGeometryLOD(geometryId, geometryLOD[2], 0.20); // use below 20%
  batchedMesh.addGeometryLOD(geometryId, geometryLOD[3], 0.10); // etc
  batchedMesh.addGeometryLOD(geometryId, geometryLOD[4], 0.05);
```

Ortographic LOD test based on the values above.

https://github.com/user-attachments/assets/62609015-98ad-4bb6-876c-ee3888fbd6dc

The code could be cleaned a bit, it's a first draft for which I couldn't notice any performance drop for a given number of geometries on screen between the two camera and the previous version.
